### PR TITLE
Fix instructions for getting API credentials

### DIFF
--- a/source/introduction.rst
+++ b/source/introduction.rst
@@ -39,7 +39,7 @@ Introduction
 Creating a client
 ==================================
 
-Log into your AniList account (or create one if you haven't already) and go to `/developer <http://anilist.co/developer>`_. Click the plus in the top right and enter your client's information, once saved you will receive your client id and secret.
+Log into your AniList account (or create one if you haven't already) and go to `the developer settings <https://anilist.co/settings/developer>`_. Click 'Create New Client' and enter your client's information, once saved you will receive your client id and secret.
 
 
 ==================================


### PR DESCRIPTION
i was left flailing p wildly for a bit there; [searching](https://encrypted.google.com/search?hl=en&q=anilist.co%20developer) didn't really help either, which i think is because the 404 page is a redirect rather than an actual redirect, so search engines are happy to index it